### PR TITLE
added =encoding directives to meet newer POD formatting requirements

### DIFF
--- a/lib/Config/Find.pm
+++ b/lib/Config/Find.pm
@@ -126,6 +126,8 @@ sub parse_opts {
 1;
 __END__
 
+=encoding utf-8
+
 =head1 NAME
 
 Config::Find - Find configuration files in the native OS fashion

--- a/lib/Config/Find/Any.pm
+++ b/lib/Config/Find/Any.pm
@@ -177,6 +177,8 @@ sub my_getlogin {
 
 __END__
 
+=encoding utf-8
+
 =head1 NAME
 
 Config::Find::Any - Perl base class for Config::Find

--- a/lib/Config/Find/Unix.pm
+++ b/lib/Config/Find/Unix.pm
@@ -200,10 +200,10 @@ sub look_for_dir_file {
 }
 
 
-
-
 1;
 __END__
+
+=encoding utf-8
 
 =head1 NAME
 

--- a/lib/Config/Find/Where.pm
+++ b/lib/Config/Find/Where.pm
@@ -138,6 +138,12 @@ sub parse_opts {
     return ($name, $more_name, $create, $dn, $scope);
 }
 
+1;
+
+__END__
+
+=encoding utf-8
+
 =head1 NAME
 
 Config::Find::Where - Find locations in the native OS fashion

--- a/lib/Config/Find/Win2k.pm
+++ b/lib/Config/Find/Win2k.pm
@@ -12,6 +12,8 @@ our @ISA = qw(Config::Find::WinAny);
 1;
 __END__
 
+=encoding utf-8
+
 =head1 NAME
 
 Config::Find::Win2k - Win2k idiosyncrasies for Config::Find

--- a/lib/Config/Find/Win2k3.pm
+++ b/lib/Config/Find/Win2k3.pm
@@ -12,6 +12,8 @@ our @ISA = qw(Config::Find::WinAny);
 1;
 __END__
 
+=encoding utf-8
+
 =head1 NAME
 
 Config::Find::Win2k - Win2k idiosyncrasies for Config::Find

--- a/lib/Config/Find/Win95.pm
+++ b/lib/Config/Find/Win95.pm
@@ -12,6 +12,8 @@ our @ISA = qw(Config::Find::WinAny);
 1;
 __END__
 
+=encoding utf-8
+
 =head1 NAME
 
 Config::Find::Win95 - Win95 idiosyncrasies for Config::Find

--- a/lib/Config/Find/Win98.pm
+++ b/lib/Config/Find/Win98.pm
@@ -12,6 +12,8 @@ our @ISA = qw(Config::Find::WinAny);
 1;
 __END__
 
+=encoding utf-8
+
 =head1 NAME
 
 Config::Find::Win98 - Win98 idiosyncrasies for Config::Find

--- a/lib/Config/Find/WinAny.pm
+++ b/lib/Config/Find/WinAny.pm
@@ -151,6 +151,8 @@ sub look_for_dir_file {
 1;
 __END__
 
+=encoding utf-8
+
 =head1 NAME
 
 Config::Find::WinAny - Behaviours common to any Win32 OS for Config::Find

--- a/lib/Config/Find/WinCE.pm
+++ b/lib/Config/Find/WinCE.pm
@@ -12,6 +12,8 @@ our @ISA = qw(Config::Find::WinAny);
 1;
 __END__
 
+=encoding utf-8
+
 =head1 NAME
 
 Config::Find::WinCE - WinCE idiosyncrasies for Config::Find

--- a/lib/Config/Find/WinME.pm
+++ b/lib/Config/Find/WinME.pm
@@ -12,6 +12,8 @@ our @ISA = qw(Config::Find::WinAny);
 1;
 __END__
 
+=encoding utf-8
+
 =head1 NAME
 
 Config::Find::WinME - WinME idiosyncrasies for Config::Find

--- a/lib/Config/Find/WinNT.pm
+++ b/lib/Config/Find/WinNT.pm
@@ -12,6 +12,8 @@ our @ISA = qw(Config::Find::WinAny);
 1;
 __END__
 
+=encoding utf-8
+
 =head1 NAME
 
 Config::Find::WinNT - WinNT idiosyncrasies for Config::Find

--- a/lib/Config/Find/WinXP.pm
+++ b/lib/Config/Find/WinXP.pm
@@ -12,6 +12,8 @@ our @ISA = qw(Config::Find::WinAny);
 1;
 __END__
 
+=encoding utf-8
+
 =head1 NAME
 
 Config::Find::WinXP - WinXP idiosyncrasies for Config::Find


### PR DESCRIPTION
This fixes RT #78944 - https://rt.cpan.org/Public/Bug/Display.html?id=78944

Newer versions of POD::Simple, detect errors in file encodings, this patch adds the UTF8 encoding directives.
